### PR TITLE
Fix Claude Code native binary detection and MCP config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ Detected IDEs: VS Code, Cursor, Claude Code CLI, Windsurf, Zed, IntelliJ IDEA, W
 ### MCP Config Cross-Referencing
 
 devreap reads your IDE's MCP configuration files:
-- `~/.claude.json` (Claude Code)
+- `~/.claude/mcp.json` (Claude Code — native binary)
+- `~/.claude.json` (Claude Code — legacy node_modules install)
 - `~/.cursor/mcp.json` (Cursor)
 - `~/.vscode/mcp.json` (VS Code)
 

--- a/internal/scanner/mcp.go
+++ b/internal/scanner/mcp.go
@@ -35,6 +35,7 @@ func LoadMCPConfigs() MCPLoadResult {
 
 	paths := []string{
 		filepath.Join(home, ".claude.json"),
+		filepath.Join(home, ".claude", "mcp.json"),
 		filepath.Join(home, ".cursor", "mcp.json"),
 		filepath.Join(home, ".vscode", "mcp.json"),
 		filepath.Join(home, "Library", "Application Support", "Code", "User", "settings.json"),

--- a/internal/scanner/process.go
+++ b/internal/scanner/process.go
@@ -15,6 +15,7 @@ type ProcessInfo struct {
 	PID        int32
 	PPID       int32
 	Name       string
+	Exe        string
 	Cmdline    string
 	Args       string
 	CreateTime time.Time
@@ -66,6 +67,7 @@ func processToInfo(p *process.Process, portMap map[int32][]uint32) *ProcessInfo 
 	}
 
 	ppid, _ := p.Ppid()
+	exe, _ := p.Exe()
 	cmdline, _ := p.Cmdline()
 	createMs, _ := p.CreateTime()
 	terminal, _ := p.Terminal()
@@ -92,6 +94,7 @@ func processToInfo(p *process.Process, portMap map[int32][]uint32) *ProcessInfo 
 		PID:        p.Pid,
 		PPID:       ppid,
 		Name:       name,
+		Exe:        exe,
 		Cmdline:    cmdline,
 		Args:       args,
 		CreateTime: createTime,

--- a/internal/scanner/scorer.go
+++ b/internal/scanner/scorer.go
@@ -29,6 +29,7 @@ var ideSignatures = []ideSignature{
 	// Claude Code CLI — match the actual binary, not anything with "claude" in it
 	{pathContains: "/node_modules/.bin/claude"},
 	{pathContains: "/@anthropic-ai/claude-code"},
+	{pathContains: "/.local/share/claude/"},
 
 	// Windsurf
 	{pathContains: "/Windsurf.app/"},
@@ -145,7 +146,7 @@ func checkIDERunningFromList(procs []ProcessInfo) bool {
 
 	for _, p := range procs {
 		for _, sig := range ideSignatures {
-			if sig.pathContains != "" && strings.Contains(p.Cmdline, sig.pathContains) {
+			if sig.pathContains != "" && (strings.Contains(p.Cmdline, sig.pathContains) || strings.Contains(p.Exe, sig.pathContains)) {
 				return true
 			}
 			if sig.exactName != "" && p.Name == sig.exactName {

--- a/internal/scanner/scorer_test.go
+++ b/internal/scanner/scorer_test.go
@@ -229,7 +229,7 @@ func TestIDEDetectionClaude(t *testing.T) {
 		t.Error("Random claude-helper should NOT be detected as an IDE")
 	}
 
-	// Actual Claude Code CLI should be detected
+	// Actual Claude Code CLI (node_modules install) should be detected
 	procs = []ProcessInfo{
 		{
 			Name:    "node",
@@ -237,7 +237,19 @@ func TestIDEDetectionClaude(t *testing.T) {
 		},
 	}
 	if !checkIDERunningFromList(procs) {
-		t.Error("Claude Code CLI should be detected as an IDE")
+		t.Error("Claude Code CLI (node_modules) should be detected as an IDE")
+	}
+
+	// Claude Code native binary (installed via ~/.local/share/claude/) should be detected via Exe path
+	procs = []ProcessInfo{
+		{
+			Name:    "2.1.74",
+			Exe:     "/Users/testuser/.local/share/claude/versions/2.1.74",
+			Cmdline: "claude --dangerously-skip-permissions",
+		},
+	}
+	if !checkIDERunningFromList(procs) {
+		t.Error("Claude Code native binary should be detected as an IDE via Exe path")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `~/.claude/mcp.json` to MCP config discovery paths — this is where Claude Code actually stores MCP server definitions (not `~/.claude.json`, which is the global settings file with no root-level `mcpServers` key)
- Add `Exe` field to `ProcessInfo` (resolved binary path via gopsutil `p.Exe()`) and check it in IDE signature matching
- Add `/.local/share/claude/` path signature for native Claude Code binary detection

## Problem

devreap repeatedly killed legitimate Claude Code MCP servers (score 0.65, threshold 0.60) due to two false positives:

1. **`parent_ide_dead` signal (0.30)**: Claude Code's native binary installs to `~/.local/share/claude/versions/<ver>`. macOS reports the process name as the version number (e.g. `2.1.72`) and `cmdline` as just `claude` without the full path. The existing signatures only matched `node_modules` paths, missing the native install entirely.

2. **Missing MCP config**: `LoadMCPConfigs()` searched `~/.claude.json` but Claude Code stores MCP servers at `~/.claude/mcp.json`. Without seeing the config, devreap couldn't correlate running MCP servers to their parent IDE.

Combined with `has_listener=0.20` and `no_tty=0.15`, this scored 0.65 and triggered kills every 30 seconds in a fight with Claude Code's reconnect logic.

## After this fix

- `devreap doctor` reports "Found 4 MCP server configs" (was "No MCP server configs found")
- MCP server scores drop from 0.65 → 0.15 (only `no_tty`)
- `parent_ide_dead` no longer fires when Claude Code is running

## Test plan

- [x] All existing tests pass
- [x] New test: native Claude Code binary detected via `Exe` path
- [x] `devreap doctor` finds MCP configs from `~/.claude/mcp.json`
- [x] `devreap scan -v` shows MCP servers as "safe" with score 0.15

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)