### PR TITLE
Fix native Claude Code binary IDE detection

### DIFF
--- a/internal/scanner/process.go
+++ b/internal/scanner/process.go
@@ -15,6 +15,7 @@ type ProcessInfo struct {
 	PID        int32
 	PPID       int32
 	Name       string
+	Exe        string
 	Cmdline    string
 	Args       string
 	CreateTime time.Time
@@ -66,6 +67,7 @@ func processToInfo(p *process.Process, portMap map[int32][]uint32) *ProcessInfo 
 	}
 
 	ppid, _ := p.Ppid()
+	exe, _ := p.Exe()
 	cmdline, _ := p.Cmdline()
 	createMs, _ := p.CreateTime()
 	terminal, _ := p.Terminal()
@@ -92,6 +94,7 @@ func processToInfo(p *process.Process, portMap map[int32][]uint32) *ProcessInfo 
 		PID:        p.Pid,
 		PPID:       ppid,
 		Name:       name,
+		Exe:        exe,
 		Cmdline:    cmdline,
 		Args:       args,
 		CreateTime: createTime,

--- a/internal/scanner/scorer.go
+++ b/internal/scanner/scorer.go
@@ -29,6 +29,7 @@ var ideSignatures = []ideSignature{
 	// Claude Code CLI — match the actual binary, not anything with "claude" in it
 	{pathContains: "/node_modules/.bin/claude"},
 	{pathContains: "/@anthropic-ai/claude-code"},
+	{pathContains: "/.local/share/claude/"},
 
 	// Windsurf
 	{pathContains: "/Windsurf.app/"},
@@ -145,7 +146,7 @@ func checkIDERunningFromList(procs []ProcessInfo) bool {
 
 	for _, p := range procs {
 		for _, sig := range ideSignatures {
-			if sig.pathContains != "" && strings.Contains(p.Cmdline, sig.pathContains) {
+			if sig.pathContains != "" && (strings.Contains(p.Cmdline, sig.pathContains) || strings.Contains(p.Exe, sig.pathContains)) {
 				return true
 			}
 			if sig.exactName != "" && p.Name == sig.exactName {

--- a/internal/scanner/scorer_test.go
+++ b/internal/scanner/scorer_test.go
@@ -229,7 +229,7 @@ func TestIDEDetectionClaude(t *testing.T) {
 		t.Error("Random claude-helper should NOT be detected as an IDE")
 	}
 
-	// Actual Claude Code CLI should be detected
+	// Actual Claude Code CLI (node_modules install) should be detected
 	procs = []ProcessInfo{
 		{
 			Name:    "node",
@@ -237,7 +237,19 @@ func TestIDEDetectionClaude(t *testing.T) {
 		},
 	}
 	if !checkIDERunningFromList(procs) {
-		t.Error("Claude Code CLI should be detected as an IDE")
+		t.Error("Claude Code CLI (node_modules) should be detected as an IDE")
+	}
+
+	// Claude Code native binary should be detected via Exe path
+	procs = []ProcessInfo{
+		{
+			Name:    "claude",
+			Exe:     "/Users/testuser/.local/share/claude/versions/2.1.74",
+			Cmdline: "claude --dangerously-skip-permissions",
+		},
+	}
+	if !checkIDERunningFromList(procs) {
+		t.Error("Claude Code native binary should be detected as an IDE via Exe path")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `Exe` field to `ProcessInfo` (resolved binary path via gopsutil `p.Exe()`) and check it in IDE signature matching alongside `Cmdline`
- Add `/.local/share/claude/` path signature for native Claude Code binary detection

## Problem

The native Claude Code binary installs to `~/.local/share/claude/versions/<ver>` and is symlinked from `~/.local/bin/claude`. On macOS, gopsutil reports the process cmdline as just `claude` (the symlink name) without the full path. The existing IDE signatures only match node_modules paths:

```go
{pathContains: "/node_modules/.bin/claude"},
{pathContains: "/@anthropic-ai/claude-code"},
```

Neither matches, so `parent_ide_dead` fires on all MCP servers even when Claude Code is actively running. Any MCP server that also has `has_listener` scores 0.65 (above the 0.60 threshold) and gets killed every 30 seconds.

## Fix

`gopsutil`'s `p.Exe()` resolves symlinks and returns the actual binary path (e.g. `/Users/x/.local/share/claude/versions/2.1.74`), which matches the new signature.

**Before:** All MCP servers score 0.45+ (`no_tty` + `parent_ide_dead`), one at 0.65 (KILL)
**After:** All MCP servers score 0.15 (`no_tty` only), system clean

## Test plan

- [x] New test: native Claude Code binary detected via `Exe` path
- [x] Existing Claude Code node_modules test still passes
- [x] All 35 scanner tests pass
- [x] Live verification: `devreap scan -v` shows "No orphan candidates found"

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)